### PR TITLE
Makepnd deps && pkgver

### DIFF
--- a/makepnd/PNDBUILD
+++ b/makepnd/PNDBUILD
@@ -7,6 +7,12 @@ pkgdesc='Scripts for creating PND packages from recipe'
 url='https://github.com/Cloudef/makepnd'
 license=('GPL')
 source=('git+git://github.com/Cloudef/makepnd.git')
+depends=('bash' 'libarchive' 'fakeroot' 'gawk'
+         'bzip2' 'coreutils' 'file' 'findutils'
+         'gettext' 'grep' 'gzip' 'openssl' 'sed'
+         'ncurses' 'xz' 'binutils' 'ldd' 'squashfs-tools'
+         'libxml2-utils')
+
 
 build() {
   cd makepnd

--- a/makepnd/PNDBUILD
+++ b/makepnd/PNDBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Jari Vetoniemi <mailRoxas@gmail.com>
 
 pkgname=makepnd
-pkgver=1.0.0
-pkgrel=2
+pkgver=r28.c9d679e
+pkgrel=1
 pkgdesc='Scripts for creating PND packages from recipe'
 url='https://github.com/Cloudef/makepnd'
 license=('GPL')
@@ -13,6 +13,10 @@ depends=('bash' 'libarchive' 'fakeroot' 'gawk'
          'ncurses' 'xz' 'binutils' 'ldd' 'squashfs-tools'
          'libxml2-utils')
 
+pkgver() {
+  cd makepnd
+  printf 'r%s.%s' "$(git rev-list --count HEAD)" "$(git describe --always)"
+}
 
 build() {
   cd makepnd


### PR DESCRIPTION
**Don't merge yet**
The pkgver change is broken with the version of 'sed' we have. It doesn't have option `--follow-symlinks` which makepnd uses. I can add workaround to makepnd or we can provide updated sed?